### PR TITLE
Add prefix "[!] " to island names to see which islands have missing factories

### DIFF
--- a/src/world.ts
+++ b/src/world.ts
@@ -612,8 +612,8 @@ export class Island {
         this.sessionExtendedName = ko.pureComputed(() => {
             let prefix = '';
 
-            const missingFactories = this.factories.filter(
-                (factory: Factory): boolean => factory.isHighlightedAsMissing()
+            const missingFactories = this.products.filter(
+                (product: Product): boolean => product.isHighlightedAsMissing()
             );
             if (missingFactories.length > 0) {
                 prefix = '[!] ';

--- a/src/world.ts
+++ b/src/world.ts
@@ -610,10 +610,16 @@ export class Island {
             literalsMap.set(key, view.literalsMap.get(key));
 
         this.sessionExtendedName = ko.pureComputed(() => {
-            if (!this.session)
-                return this.name();
+            let prefix = '';
 
-            return `${this.session.name()} - ${this.name()}`;
+            const missingFactories = this.factories.filter(
+                (factory: Factory): boolean => factory.isHighlightedAsMissing()
+            );
+            if (missingFactories.length > 0) {
+                prefix = '[!] ';
+            }
+
+            return `${prefix}${this.session.name()} - ${this.name()}`;
         });
 
         // procedures to persist inputs


### PR DESCRIPTION
This way you don't have to click through all islands to check which islands have missing buildings. You can just look at the island selectbox to see which islands need attention.

Automatically hides when "Show missing factories" option is deactivated. 

Also adjusts the island names not only in the main selectbox but also when creating trading routes.